### PR TITLE
add -f opt. in logutil-service to use fifo as input or default to stdin

### DIFF
--- a/builder/build-latest
+++ b/builder/build-latest
@@ -100,12 +100,9 @@ for edition in "${editions[@]}"; do
 
   # fix perms for utilities
   chmod 0755 $overlaydstpath/usr/bin/fix-attrs
-  chmod 0755 $overlaydstpath/usr/bin/logutil-newfifo
-  chmod 0755 $overlaydstpath/usr/bin/logutil-service
+  chmod 0755 $overlaydstpath/usr/bin/logutil-{newfifo,service,service-main}
   chmod 0755 $overlaydstpath/usr/bin/printcontenv
-  chmod 0755 $overlaydstpath/usr/bin/with-contenv
-  chmod 0755 $overlaydstpath/usr/bin/with-notifywhenup
-  chmod 0755 $overlaydstpath/usr/bin/with-retries
+  chmod 0755 $overlaydstpath/usr/bin/with-{contenv,notifywhenup,retries}
 
   # fix init perms
   chmod 0755 $overlaydstpath/init

--- a/builder/overlay-rootfs/usr/bin/logutil-newfifo
+++ b/builder/overlay-rootfs/usr/bin/logutil-newfifo
@@ -19,7 +19,7 @@ if
 }
 if
 {
-  backtick -n name { s6-uniquename fifo }
+  backtick -n name { s6-uniquename ${1} }
   import -u name
   redirfd -rnb 0 ${1}
   s6-fdholder-store /var/run/s6/fdholderd-socket ${name}

--- a/builder/overlay-rootfs/usr/bin/logutil-service
+++ b/builder/overlay-rootfs/usr/bin/logutil-service
@@ -1,17 +1,20 @@
-#!/usr/bin/execlineb -S0
+#!/usr/bin/execlineb
 
 # test if arguments were given
-if { s6-test ${#} -ge 2 }
+elgetopt "f:"
+multisubstitute
+{
+  importas -u -D "" fifo ELGETOPT_f
+}
+elgetpositionals -P0
+emptyenv -P
+if { s6-test ${#} -ge 1 }
 
 
-# this env decides what to log and how.
-backtick -D "n20 s1000000 T" -n S6_LOGGING_SCRIPT { printcontenv S6_LOGGING_SCRIPT }
-import -u -sCd" \t" S6_LOGGING_SCRIPT
-
-
-# redirect fifo to s6-log
-redirfd -rnb 0 ${1}
-s6-envuidgid -D 32768:32768 nobody
-s6-applyuidgid -U
-exec -c
-s6-log -bp -- ${S6_LOGGING_SCRIPT} ${2}
+# switch between std{out,err} or fifo
+ifelse { s6-test -n ${fifo} }
+{
+  redirfd -rnb 0 ${fifo}
+  logutil-service-main ${1}
+}
+logutil-service-main ${1}

--- a/builder/overlay-rootfs/usr/bin/logutil-service-main
+++ b/builder/overlay-rootfs/usr/bin/logutil-service-main
@@ -1,0 +1,11 @@
+#!/usr/bin/execlineb -S1
+
+# this env decides what to log and how.
+backtick -D "n20 s1000000 T" -n S6_LOGGING_SCRIPT { printcontenv S6_LOGGING_SCRIPT }
+import -u -sCd" \t" S6_LOGGING_SCRIPT
+
+# execute s6-log and drop root rights in favor of nobody
+s6-envuidgid -D 32768:32768 nobody
+s6-applyuidgid -U
+exec -c
+s6-log -bp -- ${S6_LOGGING_SCRIPT} ${1}


### PR DESCRIPTION
Also, now `logutil-newfifo` will prefix with fifopath before registering it to fdholder, just to debug issues more easily.