### PR TITLE
update to latest skaware: v1.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Init stages](#init-stages)
 - [Usage](#usage)
   - [Using `CMD`](#using-cmd)
-  - [Fixing ownership & permissions](#fixing-ownership-&-permissions)
+  - [Fixing ownership & permissions](#fixing-ownership--permissions)
   - [Executing initialization And/Or finalization tasks](#executing-initialization-andor-finalization-tasks)
   - [Writing a service script](#writing-a-service-script)
   - [Dropping privileges](#dropping-privileges)

--- a/builder/build-latest
+++ b/builder/build-latest
@@ -6,7 +6,7 @@ set -x
 ## PARAMS
 ##
 
-RELEASE_VERSION=${RELEASE_VERSION:-1.13.0.0}
+RELEASE_VERSION=${RELEASE_VERSION:-1.14.0.0}
 SKAWARE_VERSION=${RELEASE_VERSION%.*}
 
 PWD=$(pwd)
@@ -102,7 +102,7 @@ for edition in "${editions[@]}"; do
   chmod 0755 $overlaydstpath/usr/bin/fix-attrs
   chmod 0755 $overlaydstpath/usr/bin/logutil-{newfifo,service,service-main}
   chmod 0755 $overlaydstpath/usr/bin/printcontenv
-  chmod 0755 $overlaydstpath/usr/bin/with-{contenv,notifywhenup,retries}
+  chmod 0755 $overlaydstpath/usr/bin/with-{contenv,retries}
 
   # fix init perms
   chmod 0755 $overlaydstpath/init

--- a/builder/overlay-rootfs/usr/bin/with-notifywhenup
+++ b/builder/overlay-rootfs/usr/bin/with-notifywhenup
@@ -1,5 +1,0 @@
-#!/usr/bin/execlineb -S0
-# DO NOT USE THIS, it's deprecated. Use a "notification-fd" file + s6-echo instead.
-foreground { s6-notifywhenup -f s6-echo }
-unexport ?
-$@


### PR DESCRIPTION
**WARNING**: `s6-notifywhenup` no longer exists in `s6` package so consequently `with-notifywhenup` was removed from overlay.