### PR TITLE
New S6_CMD_ARG0 variable to prepend CMD when passed to /init

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ It is possible somehow to tweak `s6` behaviour by providing an already predefine
 * `S6_KILL_FINISH_MAXTIME` (default = 5000): The maximum time (in milliseconds) a script in `/etc/cont-finish.d` could take before sending a `KILL` signal to it. Take into account that this parameter will be used per each script execution, it's not a max time for the whole set of scripts.
 * `S6_KILL_GRACETIME` (default = 3000): How long (in milliseconds) `s6` should wait to reap zombies before sending a `KILL` signal.
 * `S6_LOGGING_SCRIPT` (default = "n20 s1000000 T"): This env decides what to log and how, by default every line will prepend with ISO8601, rotated when the current logging file reaches 1mb and archived, at most, with 20 files.
+* `S6_CMD_ARG0` (default = not set): Value of this env var will be prepended to any `CMD` args passed by docker. Use it if you are migrting an existing image to a s6-overlay and want to make it a drop-in replacement, then setting this variable to a value of previously used ENTRYPOINT will improve compatibility with the way image is used.
 
 ## Known issues and workarounds
 

--- a/builder/overlay-rootfs/etc/s6/init/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage1
@@ -49,6 +49,9 @@ ifthenelse -s { ${DO_NOT_KEEP_ENV} }
 }
 { }
 
+backtick -n S6_CMD_ARG0 { printcontenv S6_CMD_ARG0 }
+importas -d "\n" -s -u S6_CMD_ARG0 S6_CMD_ARG0
+
 ##
 ## route based on what was provided in S6_LOGGING
 ##
@@ -57,6 +60,6 @@ backtick -D 0 -n S6_LOGGING { printcontenv S6_LOGGING }
 importas -u S6_LOGGING S6_LOGGING
 ifelse { s6-test ${S6_LOGGING} -ne 0 }
 {
-  /etc/s6/init-catchall/init-stage1 $@
+  /etc/s6/init-catchall/init-stage1 ${S6_CMD_ARG0} $@
 }
-/etc/s6/init-no-catchall/init-stage1 $@
+/etc/s6/init-no-catchall/init-stage1 ${S6_CMD_ARG0} $@


### PR DESCRIPTION
When migrating an existing image to a s6-overlay, one might
want to prepend CMD with a previously used `ENTRYPOINT`, so that
new image can be as a drop in replacement and no changes
to the way it is used/called are required.

This is not ideal in the current form as it would split value into separate args (because of `import -s`), but I couldn't figure out how to make `backtick` NOT to set env var if `prog` exited with an error.