### PR TITLE
Add new S6_KEEP_ENV mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ This script will output whatever the `MYENV` enviroment variable contains.
 
 It is possible somehow to tweak `s6` behaviour by providing an already predefined set of environment variables to the execution context:
 
+* `S6_KEEP_ENV` (default = 0): if set, then environment is not reset and whole supervision tree sees original set of env vars. It switches `with-contenv` into noop.
 * `S6_LOGGING` (default = 0): 
   * **`0`**: Outputs everything to stdout/stderr.
   * **`1`**: Uses an internal `catch-all` logger and persists everything on it, it is located in `/var/log/s6-uncaught-logs`. Nothing would be written to stdout/stderr.

--- a/builder/overlay-rootfs/etc/s6/init/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage1
@@ -1,12 +1,20 @@
 #!/bin/execlineb -S0
 
 ##
-## dump environment into an envdir
+## dump environment into an envdir if S6_KEEP_ENV is unset
 ##
 
-if { s6-mkdir -pm 0755 -- /var/run/s6/container_environment }
-if { s6-dumpenv -- /var/run/s6/container_environment }
-
+import -D 0 S6_KEEP_ENV
+define -s DO_NOT_KEEP_ENV "s6-test ${S6_KEEP_ENV} -eq 0"
+if
+{
+  ifelse { ${DO_NOT_KEEP_ENV} }
+  {
+    if { s6-mkdir -pm 0755 -- /var/run/s6/container_environment }
+    s6-dumpenv -- /var/run/s6/container_environment
+  }
+  exit 0
+}
 
 ##
 ## create env folder for each init stage, although stage1 is always copied from
@@ -21,6 +29,7 @@ if
   importas -u envdir envdir
   s6-rmrf ${envdir}
 }
+if { s6-mkdir -pm 0755 -- /var/run/s6 }
 if { s6-hiercopy /etc/s6/init/env /var/run/s6/env-stage1 }
 if { s6-mkdir -pm 0755 -- /var/run/s6/env-stage2 }
 if { s6-mkdir -pm 0755 -- /var/run/s6/env-stage3 }
@@ -28,14 +37,17 @@ if { s6-mkdir -pm 0755 -- /var/run/s6/env-stage3 }
 
 ##
 ## run everything else with only the environment defined in
-## /var/run/s6/env-stage1. Programs can get back the container
+## /var/run/s6/env-stage1 if we are not instructed to keep
+## docker env. Programs can get back the container
 ## environment by using "with-contenv program".
 ##
 
-exec -c --
-s6-envdir /var/run/s6/env-stage1
-exec --
-
+ifthenelse -s { ${DO_NOT_KEEP_ENV} }
+{
+  exec -c --
+  s6-envdir /var/run/s6/env-stage1
+}
+{ }
 
 ##
 ## route based on what was provided in S6_LOGGING

--- a/builder/overlay-rootfs/usr/bin/printcontenv
+++ b/builder/overlay-rootfs/usr/bin/printcontenv
@@ -8,8 +8,8 @@ import -D 0 S6_KEEP_ENV
 # original docker environement
 ifelse  { s6-test ${S6_KEEP_ENV} -ne 0 }
 {
-  importas value ${1}
-  s6-echo -- ${value}
+  redirfd -w 2 /dev/null importas -i value ${1}
+  s6-echo -n -- ${value}
 }
 
 # else: original docker env was dumped into container_environment

--- a/builder/overlay-rootfs/usr/bin/printcontenv
+++ b/builder/overlay-rootfs/usr/bin/printcontenv
@@ -3,8 +3,17 @@
 # test if arguments were given
 if { s6-test ${#} -ge 1 }
 
+import -D 0 S6_KEEP_ENV
+# if S6_KEEP_ENV was passed, whole supervision tree should see
+# original docker environement
+ifelse  { s6-test ${S6_KEEP_ENV} -ne 0 }
+{
+  importas value ${1}
+  s6-echo -- ${value}
+}
 
-# print if container environment exists
+# else: original docker env was dumped into container_environment
+# retrieve it from there and print if it exists
 if { s6-test -f /var/run/s6/container_environment/${1} }
 if 
 {

--- a/builder/overlay-rootfs/usr/bin/with-contenv
+++ b/builder/overlay-rootfs/usr/bin/with-contenv
@@ -1,5 +1,11 @@
 #!/bin/execlineb -S0
-/bin/exec -c --
-/bin/s6-envdir -fn -- /var/run/s6/container_environment
-/bin/exec --
+import -D 0 S6_KEEP_ENV
+ifelse { s6-test ${S6_KEEP_ENV} -eq 0 }
+{
+  /bin/exec -c --
+  /bin/s6-envdir -fn -- /var/run/s6/container_environment
+  /bin/exec --
+  $@
+}
+
 $@


### PR DESCRIPTION
When S6_KEEP_ENV var is set, docker environment is not reset
and whole supervision tree has direct access to it.

One might want to use it if secrets are inejcted by `ENTRYPOINT`
prior to executioning overlays `/init` and company policy
prohibits saving secrets to FS.