### PR TITLE
added S6_READ_ONLY_ROOT; copy instead of link user files

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ This of course assumes that at least `/var` is backed by a writeable filesystem 
 docker run -e S6_READ_ONLY_ROOT=1 --read-only --tmpfs /var:rw,exec [image name]
 ```
 
+**NOTE**: When using `S6_READ_ONLY_ROOT=1` you should _avoid using symbolic links_ in `fix-attrs.d`, `cont-init.d`, `cont-finish.d`, and `services.d`. Due to limitations of `s6`, symbolic links will be followed when these directories are copied to `/var/run/s6`, resulting in unexpected duplication.
+
 ### Customizing `s6` behaviour
 
 It is possible somehow to tweak `s6` behaviour by providing an already predefined set of environment variables to the execution context:

--- a/README.md
+++ b/README.md
@@ -318,6 +318,16 @@ echo $MYENV
 
 This script will output whatever the `MYENV` enviroment variable contains.
 
+### Read-Only Root Filesystem
+
+Recent versions of Docker allow running containers with a read-only root filesystem. During init stage 2, the overlay modifies permissions for user-provided files in `cont-init.d`, etc. If the root filesystem is read-only, you can set `S6_READ_ONLY_ROOT=1` to inform stage 2 that it should first copy user-provided files to its work area in `/var/run/s6` before attempting to change permissions. 
+
+This of course assumes that at least `/var` is backed by a writeable filesystem with execute privileges. This could be done with a `tmpfs` filesystem as follows:
+
+```
+docker run -e S6_READ_ONLY_ROOT=1 --read-only --tmpfs /var:rw,exec [image name]
+```
+
 ### Customizing `s6` behaviour
 
 It is possible somehow to tweak `s6` behaviour by providing an already predefined set of environment variables to the execution context:
@@ -339,6 +349,7 @@ It is possible somehow to tweak `s6` behaviour by providing an already predefine
   * **`1`**: All files and directories are processed.
 * `S6_CMD_WAIT_FOR_SERVICES` (default = 0): In order to proceed executing CMD overlay will wait until services are up. Be aware that up doesn't mean ready. Depending if `notification-fd` was found inside the servicedir overlay will use `s6-svwait -U` or `s6-svwait -u` as the waiting statement.
 * `S6_CMD_WAIT_FOR_SERVICES_MAXTIME` (default = 5000): The maximum time (in milliseconds) the services could take to bring up before proceding to CMD executing.
+* `S6_READ_ONLY_ROOT` (default = 0): When running in a container whose root filesystem is read-only, set this env to **1** to inform init stage 2 that it should copy user-provided initialization scripts from `/etc` to `/var/run/s6/etc` before it attempts to change permissions, etc. See [Read-Only Root Filesystem] (#read-only-root-filesystem) for more information.
 
 ## Known issues and workarounds
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [Writing a service script](#writing-a-service-script)
   - [Writing an optional finish script](#writing-an-optional-finish-script)
   - [Dropping privileges](#dropping-privileges)
+  - [Read-only Root Filesystem](#read-only-root-filesystem)
   - [Container environment](#container-environment)
   - [Customizing `s6` behaviour](#customizing-s6-behaviour)
 - [Known issues and workarounds](#known-issues-and-workarounds)
@@ -349,7 +350,7 @@ It is possible somehow to tweak `s6` behaviour by providing an already predefine
   * **`1`**: All files and directories are processed.
 * `S6_CMD_WAIT_FOR_SERVICES` (default = 0): In order to proceed executing CMD overlay will wait until services are up. Be aware that up doesn't mean ready. Depending if `notification-fd` was found inside the servicedir overlay will use `s6-svwait -U` or `s6-svwait -u` as the waiting statement.
 * `S6_CMD_WAIT_FOR_SERVICES_MAXTIME` (default = 5000): The maximum time (in milliseconds) the services could take to bring up before proceding to CMD executing.
-* `S6_READ_ONLY_ROOT` (default = 0): When running in a container whose root filesystem is read-only, set this env to **1** to inform init stage 2 that it should copy user-provided initialization scripts from `/etc` to `/var/run/s6/etc` before it attempts to change permissions, etc. See [Read-Only Root Filesystem] (#read-only-root-filesystem) for more information.
+* `S6_READ_ONLY_ROOT` (default = 0): When running in a container whose root filesystem is read-only, set this env to **1** to inform init stage 2 that it should copy user-provided initialization scripts from `/etc` to `/var/run/s6/etc` before it attempts to change permissions, etc. See [Read-Only Root Filesystem](#read-only-root-filesystem) for more information.
 
 ## Known issues and workarounds
 

--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -12,6 +12,11 @@ s6-envdir -I /var/run/s6/env-stage2
 backtick -D 0 -n S6_BEHAVIOUR_IF_STAGE2_FAILS { printcontenv S6_BEHAVIOUR_IF_STAGE2_FAILS }
 importas -u S6_BEHAVIOUR_IF_STAGE2_FAILS S6_BEHAVIOUR_IF_STAGE2_FAILS
 
+# This env determines whether user provided files in /etc should be linked 
+# or copied into /var/run/s6
+backtick -D 0 -n S6_READ_ONLY_ROOT { printcontenv S6_READ_ONLY_ROOT }
+importas -u S6_READ_ONLY_ROOT S6_READ_ONLY_ROOT
+
 foreground
 {
   if
@@ -44,7 +49,10 @@ foreground
           if { s6-test -d ${S6_RUNTIME_PROFILE_SRC}/${i} }
           # although s6-hiercopy is prefered, and until it doesn't support 'follow symlinks'
           # option, there is no clean way to allow symlinks between user provided runcoms.
-          if { s6-ln -s ${S6_RUNTIME_PROFILE_SRC}/${i} /var/run/s6/etc/${i} }
+          ifelse { s6-test ${S6_READ_ONLY_ROOT} -eq 0 } { 
+            s6-ln -s ${S6_RUNTIME_PROFILE_SRC}/${i} /var/run/s6/etc/${i} 
+          }
+          if { s6-hiercopy ${S6_RUNTIME_PROFILE_SRC}/${i} /var/run/s6/etc/${i} }
         }
         importas -u ? ?
         if { s6-echo -- "exited ${?}." }


### PR DESCRIPTION
Allows the user to specify `S6_READ_ONLY_ROOT=1` when running a container to indicate that user-provided files in `/etc` should be copied to `/var/run/s6` instead of linked. This allows a container using s6-overlay to be run with a read-only root filesystem using

```
docker run --read-only --tmpfs /tmp --tmpfs /run --tmpfs /var:rw,exec ...
```

Based on comments in the init-stage2 source, when using this capability, user-provided files should not use symlinks due to limitations of `s6-hiercopy`.
