### PR TITLE
Make S6_CMD_WAIT_FOR_SERVICES to respect S6_BEHAVIOUR_IF_STAGE2_FAILS

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -142,17 +142,15 @@ foreground
           importas -u S6_CMD_WAIT_FOR_SERVICES_MAXTIME S6_CMD_WAIT_FOR_SERVICES_MAXTIME
 
           if -t { if { s6-test ${S6_CMD_WAIT_FOR_SERVICES} -ne 0 } s6-test $# -ne 0 }
-          if
+          s6-maximumtime -t ${S6_CMD_WAIT_FOR_SERVICES_MAXTIME}
+          pipeline { s6-ls -0 -- /var/run/s6/etc/services.d }
+          forstdin -0 -o 0 -- i
+          importas -u i i
+          ifelse { s6-test -f /var/run/s6/services/${i}/notification-fd }
           {
-            pipeline { s6-ls -0 -- /var/run/s6/etc/services.d }
-            forstdin -0 -p -- i
-            importas -u i i
-            ifelse { s6-test -f /var/run/s6/services/${i}/notification-fd }
-            {
-              s6-svwait -t ${S6_CMD_WAIT_FOR_SERVICES_MAXTIME} -U /var/run/s6/services/${i}
-            }
-            s6-svwait -t ${S6_CMD_WAIT_FOR_SERVICES_MAXTIME} -u /var/run/s6/services/${i}
+            s6-svwait -t ${S6_CMD_WAIT_FOR_SERVICES_MAXTIME} -U /var/run/s6/services/${i}
           }
+          s6-svwait -t ${S6_CMD_WAIT_FOR_SERVICES_MAXTIME} -u /var/run/s6/services/${i}
         }
         if { s6-echo -- "[services.d] done." }
       }


### PR DESCRIPTION
Waiting sequentially is only marginally slower than waiting in parallel,
but in return proper exit code can be set and handled, so that failing
services do fail startup procedure
