### PR TITLE
Make stage2 exit code available in stage3

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -159,6 +159,9 @@ foreground
     }
     importas -u ? ?
     ifelse { s6-test ${S6_BEHAVIOUR_IF_STAGE2_FAILS} -eq 0 } { exit 0 }
+
+    # Make stage2 exit code available in stage3
+    foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_STAGE2_EXITED s6-echo -n -- "${?}" }
     exit ${?}
   }
 
@@ -174,7 +177,7 @@ foreground
   if { s6-echo -- "${1} exited ${?}" }
 
   # Make CMD exit code available in stage3
-  foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_CMD_EXITED s6-echo -n -- "${?}" }
+  foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_STAGE2_EXITED s6-echo -n -- "${?}" }
 
   # Stop supervision tree
   foreground { s6-svscanctl -t /var/run/s6/services }
@@ -190,8 +193,6 @@ if { s6-test ${?} -ne 0 }
 if { s6-test ${S6_BEHAVIOUR_IF_STAGE2_FAILS} -ne 0 }
 ifelse { s6-test ${S6_BEHAVIOUR_IF_STAGE2_FAILS} -ne 1 }
 {
-  # Stop supervision tree (if it wasn't already due to CMD execution)
-  if { s6-test ! -f /var/run/s6/env-stage3/S6_CMD_EXITED }
   s6-svscanctl -t /var/run/s6/services
 }
 s6-echo -- "\n!!!!!\n init-stage2 failed.\n!!!!!"

--- a/builder/overlay-rootfs/etc/s6/init/init-stage3
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage3
@@ -73,5 +73,5 @@ foreground { s6-sync }
 
 # Use CMD exit code defaulting to zero if not present.
 
-importas -u -D0 S6_CMD_EXITED S6_CMD_EXITED
-exit ${S6_CMD_EXITED}
+importas -u -D0 S6_STAGE2_EXITED S6_STAGE2_EXITED
+exit ${S6_STAGE2_EXITED}


### PR DESCRIPTION
If init or other part of stage 2 fails - container will exit, but the exitcode will be 0

This pull request will make sure container exits with 1 if stage 2 fails
