### PR TITLE
"cmd exited ..." should use init-stage2-redirfd to honor S6_LOGGING.

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -171,8 +171,10 @@ foreground
   if -t { s6-test $# -ne 0 }
   foreground { s6-setsid -gq -- with-contenv $@ }
   importas -u ? ?
-  if { s6-echo -- "${1} exited ${?}" }
-
+  foreground {
+    /etc/s6/init/init-stage2-redirfd
+    if { s6-echo -- "[cmd] ${1} exited ${?}" }
+  }
   # Make CMD exit code available in stage3
   foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_CMD_EXITED s6-echo -n -- "${?}" }
 


### PR DESCRIPTION
We are migrating our docker images to use s6-overlay and we want to use S6_CMD_ARG0 as recommended to ease the migration of the entrypoint.  I think that the logging for CMD should honor S6_LOGGING and thus not log "cmd exited 0" to stdout, but rather to s6-uncaught-logs, if S6_LOGGING is enabled.  This can end up polluting stdout of the docker run command and adversely impact piping/parsing etc.  The absence should not be a problem since the return code is available as the return code of the docker run command.

I have attempted to make the s6-echo of the exit more in line with the logging of the other phases by adding "[cmd}" and calling init-stage2-redirfd.  I am new to s6-overlay and execlineb, so my implementation may have some effect I am not aware of, but I hope the intent is justified and some such change can be made.

Thanks for considering and thanks for the great product.

jc
