### PR TITLE
Fix for issue #216: Store the docker cmd exit code in the proper variable.

### DIFF
--- a/builder/overlay-rootfs/etc/s6/services/docker-cmd/finish
+++ b/builder/overlay-rootfs/etc/s6/services/docker-cmd/finish
@@ -1,4 +1,4 @@
 #!/bin/execlineb -S0
-foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_CMD_EXITED s6-echo -n -- "${1}" }
+foreground { redirfd -w 1 /var/run/s6/env-stage3/S6_STAGE2_EXITED s6-echo -n -- "${1}" }
 foreground { s6-echo -- "docker CMD exited ${1}" }
 s6-svscanctl -t /var/run/s6/services


### PR DESCRIPTION
The exit code of the command should be stored in `S6_STAGE2_EXITED` instead of `S6_CMD_EXITED`.

`S6_CMD_EXITED` has been renamed by commit e33f6ef3813490198844421c363f780375cad7ab.