### PR TITLE
Before creating container environment, make sure to remove any existing one.

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage1
@@ -10,6 +10,7 @@ if
 {
   ifelse { ${DO_NOT_KEEP_ENV} }
   {
+    if { s6-rmrf /var/run/s6/container_environment }
     if { s6-mkdir -pm 0755 -- /var/run/s6/container_environment }
     s6-dumpenv -- /var/run/s6/container_environment
   }


### PR DESCRIPTION
When `S6_KEEP_ENV` is set to `0`, it is expected to have the container environment reset.  This means that if during the container execution environment variables are created in 
 `/var/run/s6/container_environment`, a restart of the container should clear them, which is not the case without this fix.
