### PR TITLE
Update init-stage2 to fix "s6-test: fatal: parse error at argument 0"

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -181,6 +181,7 @@ foreground
 
   foreground {
       s6-setsid -gq -- with-contenv
+      backtick -D 0 -n S6_LOGGING { printcontenv S6_LOGGING }
       importas S6_LOGGING S6_LOGGING
       ifelse { s6-test ${S6_LOGGING} -eq 2 }
       {


### PR DESCRIPTION
fix #222 