### PR TITLE
Skip not-existing "./sbin" in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,8 @@ disappear.
 The current workaround is to extract the tarball in two steps:
 
 ```
-RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" --exclude="./sbin" && \
-    tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin ./sbin
+RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" && \
+    tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin
 ```
 
 This will prevent tar from deleting those `/bin` and `/sbin` symlinks, and


### PR DESCRIPTION
# Problem

When I build this tiny Dockerfile as a test, according to [this tutorial](https://github.com/just-containers/s6-overlay#bin-and-sbin-are-symlinks)

```dockerfile
FROM centos:latest

ADD https://github.com/just-containers/s6-overlay/releases/download/v1.21.4.0/s6-overlay-amd64.tar.gz /tmp/
RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" --exclude="./sbin"
RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin ./sbin

ENTRYPOINT /init
```

I faced following error

```sh
Step 4/5 : RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin ./sbin
 ---> Running in 31ca57642a57
tar: ./sbin: Not found in archive
tar: Exiting with failure status due to previous errors
The command '/bin/sh -c tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin ./sbin' returned a non-zero code: 2
```

# Causes

- the release build [doesn't have `./sbin`](https://github.com/just-containers/s6-overlay/blob/master/builder/build-latest), but the document has not changed 😔 

# Fix

- Change the documentation not to deal with `./sbin`

# Related

- https://github.com/just-containers/s6-overlay/issues/125#issuecomment-310674635
- https://github.com/frekele/docker-debian/commit/dfcc174b00de070da6bf1abe78025167231f3a7f