### PR TITLE
Wait for services before nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ It is possible somehow to tweak `s6` behaviour by providing an already predefine
   * **`1`**: Continue but warn with an annoying error message.
   * **`2`**: Stop by sending a termination signal to the supervision tree.
 * `S6_KILL_FINISH_MAXTIME` (default = 5000): The maximum time (in milliseconds) a script in `/etc/cont-finish.d` could take before sending a `KILL` signal to it. Take into account that this parameter will be used per each script execution, it's not a max time for the whole set of scripts.
+* `S6_SERVICES_GRACETIME` (default = 3000): How long (in milliseconds) `s6` should wait services before sending a `TERM` signal.
 * `S6_KILL_GRACETIME` (default = 3000): How long (in milliseconds) `s6` should wait to reap zombies before sending a `KILL` signal.
 * `S6_LOGGING_SCRIPT` (default = "n20 s1000000 T"): This env decides what to log and how, by default every line will prepend with ISO8601, rotated when the current logging file reaches 1mb and archived, at most, with 20 files.
 * `S6_CMD_ARG0` (default = not set): Value of this env var will be prepended to any `CMD` args passed by docker. Use it if you are migrting an existing image to a s6-overlay and want to make it a drop-in replacement, then setting this variable to a value of previously used ENTRYPOINT will improve compatibility with the way image is used.

--- a/builder/overlay-rootfs/etc/s6/init/init-stage3
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage3
@@ -35,6 +35,17 @@ foreground
   }
 }
 
+# Wait service down
+
+foreground { s6-echo "[s6-finish] waiting for services." }
+foreground
+{
+  backtick -D 3000 -n S6_SERVICES_GRACETIME { printcontenv S6_SERVICES_GRACETIME }
+  importas -u S6_SERVICES_GRACETIME S6_SERVICES_GRACETIME
+  elglob SERVICES /var/run/s6/services/*
+  foreground { s6-svwait -D -t ${S6_SERVICES_GRACETIME} ${SERVICES} }
+  s6-sleep -m 200
+}
 
 # Sync before TERM'n
 


### PR DESCRIPTION
##### Behavior
If I understand correctly when we run `docker stop $container_id`, docker send a SIGTERM to `s6-svscan`.
Then the program forward `SIGTERM` to s6-supervise which in turn forward the signal to `run` programs.
In parallel, s6-overlay run stage3 that iterate over cont-finish.d scripts and then kills everything by sending again a `SIGTERM`.
In some cases, when we need to do a graceful shutdown we have to trap the signal and perform various operations that can take times.
And in various cases, s6-overlay send the second `SIGTERM` too early and kills those operations.
It should be interesting to wait services before sending `s6-nuke`. 

##### Minimal yet complete reproducer code (or URL to code)
[https://github.com/amannocci/s6-overlay-fix](https://github.com/amannocci/s6-overlay-fix)

Signed-off-by: amannocci <adrien.mannocci@gmail.com>