### PR TITLE
Ensure any ./data/check script is executable

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage2-fixattrs.txt
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2-fixattrs.txt
@@ -5,3 +5,4 @@
 /var/run/s6/etc/services.d/*/finish false root 0755 0755
 /var/run/s6/etc/services.d/*/log/run false root 0755 0755
 /var/run/s6/etc/services.d/*/log/finish false root 0755 0755
+/var/run/s6/etc/services.d/*/data/check false root 0755 0755


### PR DESCRIPTION
A ./data/check script is executed by "s6-notifyoncheck" to implement notification readiness in daemons that don't natively support it:

https://skarnet.org/software/s6/s6-notifyoncheck.html