### PR TITLE
Enable containers to start as a non-root user

### DIFF
--- a/builder/build-init.Dockerfile
+++ b/builder/build-init.Dockerfile
@@ -1,0 +1,13 @@
+FROM buildpack-deps:focal
+
+WORKDIR /workspace
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends software-properties-common \
+  && add-apt-repository -y ppa:neurobin/ppa \
+  && apt-get update \
+  && apt-get install -y shc
+
+COPY init.sh .
+
+RUN shc -S -r -f init.sh -o init

--- a/builder/build-latest
+++ b/builder/build-latest
@@ -67,6 +67,16 @@ get_packages_with_versions_from_manifest() {
   echo ${versions[@]}
 }
 
+build_init() {
+  local -r name='s6-overlay-init-builder'
+  cd "$OVERLAY_SRC_PATH/.."
+  docker build -t $name -f build-init.Dockerfile .
+  docker run -d --name $name $name sleep infinity
+  docker cp $name:/workspace/init "$OVERLAY_SRC_PATH/init"
+  docker rm -f $name
+  cd -
+}
+
 ##
 ## DOWNLOAD PACKAGES
 ##
@@ -91,6 +101,8 @@ generate_release
 ##
 ## OVERLAYS
 ##
+
+build_init
 
 for edition in "${editions[@]}"; do
   for target in "${targets[@]}"; do
@@ -140,7 +152,7 @@ for edition in "${editions[@]}"; do
     chmod 0755 $overlaydstpath/usr/bin/with-{contenv,retries,contenv-legacy}
   
     # fix init perms
-    chmod 0755 $overlaydstpath/init
+    chmod 4755 $overlaydstpath/init
     chmod 0755 $overlaydstpath/etc/s6/init/init-*
     chmod 0755 $overlaydstpath/etc/s6/init-catchall/init-*
     chmod 0755 $overlaydstpath/etc/s6/init-no-catchall/init-*

--- a/builder/init.sh
+++ b/builder/init.sh
@@ -1,4 +1,4 @@
-#!/bin/execlineb -S0
+#!/bin/sh
 
 ##
 ## load default PATH (the same that Docker includes if not provided) if it doesn't exist,
@@ -7,7 +7,10 @@
 ## - https://github.com/just-containers/s6-overlay/issues/108
 ##
 
-
+{ script=$(cat) ; } <<'HEREDOC'
 /bin/importas -D /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PATH PATH
 export PATH ${PATH}
 /etc/s6/init/init-stage1 $@
+HEREDOC
+
+exec /bin/execlineb -S0 -c "$script" -- "$@"


### PR DESCRIPTION
- [ ] Build for different archs

Fixes https://github.com/just-containers/s6-overlay/issues/19, despite it's already closed.