### PR TITLE
Fix startup on userns-remap built image

### DIFF
--- a/builder/overlay-rootfs/init
+++ b/builder/overlay-rootfs/init
@@ -10,4 +10,8 @@
 
 /bin/importas -D /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PATH PATH
 export PATH ${PATH}
-/etc/s6/init/init-stage1 $@
+
+foreground {
+    backtick -n REMAPPED_ROOT_UID { /usr/bin/stat -c '%u' /bin/s6-overlay-preinit }
+    if { s6-test $REMAPPED_ROOT_UID -ne 0 } /bin/s6-chown -u 0 /bin/s6-overlay-preinit
+} /etc/s6/init/init-stage1 $@


### PR DESCRIPTION
When the image was built on or pulled by a dockerd running with userns-remap the root filesystem will be owned by the remapped UID.  When that image is run explicitly in the host's user namespace the ownership of the files on disk will be based on the userns-remapped UIDs.  This is generally fine, except where an executable is SUID, which is the case for the s6-overlay-preinit tool, so we must detect the situation and set the ownership of the relevant tools.

This has been tested against the linuxserver/docker-unifi-controller container where the issue was identified and it does resolve the start-up problems.

The down-side of this solution is that it depends on an external `stat` binary which isn't ideal.  Open to suggestions on how this might be avoided.

See:
- https://github.com/just-containers/s6-overlay/issues/309
- https://github.com/moby/moby/issues/28986
- https://docs.docker.com/engine/security/userns-remap/#disable-namespace-remapping-for-a-container