### PR TITLE
Fix backtick commands for execline 2.8.0.0

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage1
@@ -58,7 +58,7 @@ ifthenelse -s { ${DO_NOT_KEEP_ENV} }
 }
 { }
 
-backtick -n S6_CMD_ARG0 { printcontenv S6_CMD_ARG0 }
+backtick -D "" -n S6_CMD_ARG0 { printcontenv S6_CMD_ARG0 }
 importas -d "\n" -s -u S6_CMD_ARG0 S6_CMD_ARG0
 
 ##

--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -35,7 +35,7 @@ foreground
         if { s6-echo -n -- "[s6-init] making user provided files available at /var/run/s6/etc..." }
         foreground
         {
-          backtick -n S6_RUNTIME_PROFILE { printcontenv S6_RUNTIME_PROFILE }
+          backtick -D "" -n S6_RUNTIME_PROFILE { printcontenv S6_RUNTIME_PROFILE }
           importas -u S6_RUNTIME_PROFILE S6_RUNTIME_PROFILE
           backtick -n S6_RUNTIME_PROFILE_SRC {
             ifte { s6-echo "/etc/cont-profile.d/${S6_RUNTIME_PROFILE}" } { s6-echo "/etc" }


### PR DESCRIPTION
I'm the Alpine package maintainer for s6-overlay. Alpine's Edge
"bleeding edge" version has execline 2.8.0.0 packaged and as a result
my s6-overlay 2.2.0.3 package is giving errors due to a change in
"backtick" behaviour as of execline 2.8.0.0 (detailed here:
http://skarnet.org/software/execline/upgrade.html).

This PR fixes the init-stage1 and init-stage2 scripts to work with the
newer version of execline.