### PR TITLE
Create automatic release process, update documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,29 @@ jobs:
         run: |
           echo '::set-output name=s6_arch::'$(cut -f1 conf/toolchains | sed -z '$ s/\n$//' | jq -R -s -c 'split("\n")')
 
+      - run: |
+          . conf/versions
+          printf "Binary releases include the following skaware packages:\n\n" > release-notes.md
+          printf "| Software | Version |\n" >> release-notes.md
+          printf "| -------- |:-------:|\n" >> release-notes.md
+          printf "| BearSSL | %s \n" "${BEARSSL_VERSION}" >> release-notes.md
+          printf "| skalibs | %s \n" "${SKALIBS_VERSION}" >> release-notes.md
+          printf "| execline | %s \n" "${EXECLINE_VERSION}" >> release-notes.md
+          printf "| s6 | %s \n" "${S6_VERSION}" >> release-notes.md
+          printf "| s6-rc | %s \n" "${S6_RC_VERSION}" >> release-notes.md
+          printf "| s6-linux-init | %s \n" "${S6_LINUX_INIT_VERSION}" >> release-notes.md
+          printf "| s6-portable-utils | %s \n" "${S6_PORTABLE_UTILS_VERSION}" >> release-notes.md
+          printf "| s6-linux-utils | %s \n" "${S6_LINUX_UTILS_VERSION}" >> release-notes.md
+          printf "| s6-dns | %s \n" "${S6_DNS_VERSION}" >> release-notes.md
+          printf "| s6-networking | %s \n" "${S6_NETWORKING_VERSION}" >> release-notes.md
+          printf "| s6-overlay-helpers | %s \n" "${S6_OVERLAY_HELPERS_VERSION}" >> release-notes.md
+          printf "\n" >> release-notes.md
+
       - uses: ncipollo/release-action@v1
         with:
           omitBodyDuringUpdate: true
           allowUpdates: true
+          bodyFile: release-notes.md
 
   release:
     needs: [ setup ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.s6_arch }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: matrix
+        run: |
+          echo '::set-output name=s6_arch::'$(cut -f1 conf/toolchains | sed -z '$ s/\n$//' | jq -R -s -c 'split("\n")')
+
+      - uses: ncipollo/release-action@v1
+        with:
+          omitBodyDuringUpdate: true
+          allowUpdates: true
+
+  release:
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        s6_arch: ${{fromJson(needs.setup.outputs.matrix)}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # normalize version (remove 'git/refs/', remove leading 'v')
+      - run: |
+          VERSION="${GITHUB_REF##*/}"
+          VERSION="${VERSION#v}"
+          echo "S6_VERSION=${VERSION}" >> $GITHUB_ENV
+
+      # create short arch name
+      - run: |
+          SARCH=$(echo "${{ matrix.s6_arch }}" | cut -f1 -d'-')
+          if [ "${{matrix.s6_arch}}" = "arm-linux-musleabihf" ] ; then
+            SARCH="armhf"
+          fi
+          echo "S6_ARCH=${SARCH}" >> $GITHUB_ENV
+
+      - run: |
+          make ARCH="${{ matrix.s6_arch }}" VERSION="${{ env.S6_VERSION }}"
+
+      # by default, arm-linux-musleabi and arm-linux-musleabihf produce tarballs named "arm",
+      # move arm-linux-musleabihf to "armhf" to distinguish
+      - run: |
+          cd output ; for f in s6-overlay-arm* ; do mv "$f" "s6-overlay-armhf${f#s6-overlay-arm}" ; done
+        if: ${{ matrix.s6_arch == 'arm-linux-musleabihf' }}
+
+      - run: |
+          cd output ; for f in *.tar* ; do sha256sum "$f" > "$f".sha256 ; done
+
+      # output arch-specific binary
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "output/s6-overlay-${{ env.S6_ARCH }}*"
+          omitBodyDuringUpdate: true
+          allowUpdates: true
+
+      - run: |
+          rm -v output/s6-overlay-${{ env.S6_ARCH }}*
+
+      # upload symlinks/non-arch on x86_64 only
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "output/*.tar.*"
+          omitBodyDuringUpdate: true
+          allowUpdates: true
+        if: ${{ matrix.s6_arch == 'x86_64-linux-musl' }}

--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ Build the following Dockerfile and try it out:
 ```
 # Use your favorite image
 FROM ubuntu
+ARG S6_OVERLAY_VERSION=3.0.0.0-1
+
 RUN apt-get update && apt-get install -y nginx xz-utils
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 CMD ["/usr/sbin/nginx"]
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/v3.0.0.0/s6-overlay-noarch-3.0.0.0.tar.xz /tmp
-RUN tar -C / -Jxpf /tmp/s6-overlay-noarch-3.0.0.0.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/v3.0.0.0/s6-overlay-x86_64-3.0.0.0.tar.xz /tmp
-RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64-3.0.0.0.tar.xz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch-${S6_OVERLAY_VERSION}.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-noarch-${S6_OVERLAY_VERSION}.tar.xz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64-${S6_OVERLAY_VERSION}.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64-${S6_OVERLAY_VERSION}.tar.xz
 ENTRYPOINT ["/init"]
 ```
 
@@ -716,19 +718,15 @@ gain even more performance. If you have benchmarks, please send them to us!
 
 ## Verifying Downloads
 
-The s6-overlay releases are not yet signed; we will get to it really soon.
-You can import our gpg public key:
+The s6-overlay releases have a checksum files you can use to verify
+the download using SHA256:
 
 ```sh
-$ curl https://keybase.io/justcontainers/key.asc | gpg --import
-```
-
-When we've signed the releases, you can then verify the downloaded files:
-
-```sh
-$ gpg --verify s6-overlay-x86_64-3.0.0.0.tar.xz.sig s6-overlay-x86_64-3.0.0.0.tar.xz
-gpg: Signature made Sun 22 Nov 2015 09:11:29 AM CST using RSA key ID BD7BF0DC
-gpg: Good signature from "Just Containers <just-containers@jrjrtech.com>"
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch-${S6_OVERLAY_VERSION}.tar.xz /tmp
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch-${S6_OVERLAY_VERSION}.tar.xz.sha256 /tmp
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64-${S6_OVERLAY_VERSION}.tar.xz /tmp
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64-${S6_OVERLAY_VERSION}.tar.xz.sha256 /tmp
+RUN cd /tmp && sha256sum -c *.sha256
 ```
 
 ## Notes


### PR DESCRIPTION
A few notes:

* I updated the Quick Start to use the `ARG` directive to set a variable with the current version, and updated the rest of the documentation to use that variable. This way in future documentation updates, we only need to update that ARG variable in the Quick Start.
* Ran into a small issue - running `make ARCH=arm-linux-musleabi` and `make ARCH=arm-linux-musleabihf` both produce tarballs named `s6-overlay-arm-${VERSION}.tar.xz`. So in the CI, [I rename `s6-overlay-arm-${VERSION}.tar.xz` to `s6-overlay-armhf-${VERSION}.tar.xz`](https://github.com/jprjr/s6-overlay/blob/70146fd62744fe679992e70b62dda88305b6856b/.github/workflows/release.yml#L40-L55). Not sure if the build system should be updated to handle that, or if it should stay in the CI layer.
* As discussioned in #352 - no more GPG signing, since most of the assurances GPG provides were undermined by the release process being automated.