### PR TITLE
Fix syntax for finish script example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,9 +393,9 @@ be something like this:
 #!/bin/sh
 
 if test "$1" -eq 256 ; then
-  e = $((128 + $2))
+  e=$((128 + $2))
 else
-  e = "$1"
+  e="$1"
 fi
 
 echo "$e" > /run/s6-linux-init-container-results/exitcode


### PR DESCRIPTION
It wouldn't run unless I got rid of the spaces, as [shellcheck suggested](https://github.com/koalaman/shellcheck/wiki/SC2283). As it is currently was giving me 
`./finish: 6: ./finish: e: not found`