### PR TITLE
relax link check and check first level only

### DIFF
--- a/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/libexec/preinit
+++ b/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/libexec/preinit
@@ -64,7 +64,7 @@ if test "0$UID" -ne 0 ; then
 fi
 
 # Ensure /var/run is a symlink to /run
-if test -L /var/run && test "`s6-linkname -f /var/run`" = /run ; then : ; else
+if test -L /var/run && test "`s6-linkname /var/run`" = /run ; then : ; else
   echo "$prog: notice: /var/run is not a symlink to /run, fixing it" 1>&2
   s6-rmrf /var/run
   s6-ln -s /run /var/run


### PR DESCRIPTION
This will alow multiple levels of indirection on /run, useful
when the only writable volume is not mounted on /run.

Addresses https://github.com/just-containers/s6-overlay/issues/450