### PR TITLE
Trap SIGINT in rc.init

### DIFF
--- a/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/etc/s6-linux-init/skel/rc.init
+++ b/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/etc/s6-linux-init/skel/rc.init
@@ -2,6 +2,7 @@
 
 prog=/run/s6/basedir/scripts/rc.init
 top="$1" ; shift
+trap : INT
 
 if test -d /run/s6/container_environment ; then
   s6-chmod 0755 /run/s6/container_environment
@@ -46,7 +47,7 @@ set -e
 if b=`printcontenv S6_BEHAVIOUR_IF_STAGE2_FAILS` && s6-test "$r" -gt 0 -a "$b" =~ '^[[:digit:]]+$' -a "$b" -gt 0 ; then
   echo "$prog: warning: s6-rc failed to properly bring all the services up! Check your logs (in /run/uncaught-logs/current if you have in-container logging) for more information." 1>&2
   if test "$b" -ge 2 ; then
-    echo "prog: fatal: stopping the container." 1>&2
+    echo "$prog: fatal: stopping the container." 1>&2
     echo "$r" > /run/s6-linux-init-container-results/exitcode
     exec /run/s6/basedir/bin/halt
   fi


### PR DESCRIPTION
This change makes the rc.init running so it can handle s6-rc non-zero exit code, allowing coordinated shutdown when S6_BEHAVIOUR_IF_STAGE2_FAILS is set to >= 2.

Also fixes minor typo (unexpanded variable in error message).

Fixes: #499