### PR TITLE
ci: upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: matrix
         run: |
-          echo '::set-output name=s6_arch::'$(cut -f1 conf/toolchains | sed -z '$ s/\n$//' | jq -R -s -c 'split("\n")')
+          echo s6_arch=$(cut -f1 conf/toolchains | sed -z '$ s/\n$//' | jq -R -s -c 'split("\n")') >> "$GITHUB_OUTPUT"
 
       - run: |
           . conf/versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.s6_arch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: matrix
         run: |
           echo '::set-output name=s6_arch::'$(cut -f1 conf/toolchains | sed -z '$ s/\n$//' | jq -R -s -c 'split("\n")')
@@ -48,7 +48,7 @@ jobs:
         s6_arch: ${{fromJson(needs.setup.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # normalize version (remove 'git/refs/', remove leading 'v')
       - run: |


### PR DESCRIPTION
this one uses nodejs16 which is not deprecated  

closes #509