### PR TITLE
Remove quoted space

### DIFF
--- a/layout/rootfs-overlay/init
+++ b/layout/rootfs-overlay/init
@@ -43,7 +43,7 @@ fi
 # root, can be a normal user).
 
 exec s6-overlay-suexec \
-  ' /package/admin/s6-overlay-@VERSION@/libexec/preinit' \
+  '/package/admin/s6-overlay-@VERSION@/libexec/preinit' \
   '' \
-  /package/admin/s6-overlay-@VERSION@/libexec/stage0 \
+  '/package/admin/s6-overlay-@VERSION@/libexec/stage0' \
   "$@"


### PR DESCRIPTION
Also, use single quotes for `stage0` path.

This quoted space appears to be a mistake, because I don't normally have a '/ /' directory with files under it.

If it was intentional, a comment should be added explaining why it is there.